### PR TITLE
Add support to use rust-crypto instead of openssl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ rust:
   - nightly
 
 script:
-  - cargo test --features hmac-openssl
   - cargo test --features hmac-rust-crypto
+  - cargo test --features hmac-openssl

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,7 @@ rust:
   - stable
   - beta
   - nightly
+
+script:
+  - cargo test --features hmac-openssl
+  - cargo test --features hmac-rust-crypto

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iron-hmac"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Joe Wilm <joe@jwilm.com>"]
 description = "HMAC middleware for the Iron HTTP framework"
 license = "MIT"
@@ -9,12 +9,17 @@ repository = "https://github.com/jwilm/iron-hmac"
 documentation = "https://jwilm.github.io/iron-hmac/latest/iron_hmac/"
 
 [dependencies]
-openssl = "0.7"
-iron = "0.2"
+rust-crypto = "0.2.34"
 url = "0.5"
 bodyparser = "0.0"
 persistent = "0.0"
 rustc-serialize = "0.3"
+constant_time_eq = "0.1.0"
 
-[dev-dependencies]
-hyper = "0.7"
+[dependencies.iron]
+version = "0.2"
+default-features = false
+
+[dev-dependencies.hyper]
+version = "0.7"
+default-features = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,18 +7,26 @@ license = "MIT"
 readme = "README.md"
 repository = "https://github.com/jwilm/iron-hmac"
 documentation = "https://jwilm.github.io/iron-hmac/latest/iron_hmac/"
+build = "build.rs"
+
+[features]
+default = []
+
+# Use openssl HMAC/SHA256 implementations
+hmac-openssl = ["openssl"]
+
+# Use rust-crypto HMAC/SHA256 implementations
+hmac-rust-crypto = ["rust-crypto"]
 
 [dependencies]
-rust-crypto = "0.2.34"
 url = "0.5"
-bodyparser = "0.0"
-persistent = "0.0"
+bodyparser = "0"
+persistent = { git = "https://github.com/iron/persistent", rev = "8fba58eff0ad56335b3f1a556cc83b51c882e447" }
 rustc-serialize = "0.3"
 constant_time_eq = "0.1.0"
-
-[dependencies.iron]
-version = "0.2"
-default-features = false
+rust-crypto = { version = "0.2.34", optional = true }
+openssl = { version = "0.7", optional = true }
+iron = "*"
 
 [dev-dependencies.hyper]
 version = "0.7"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+test:
+	cargo test --features hmac-rust-crypto
+	cargo test --features hmac-openssl

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,10 @@
+fn main() {
+    let ssl = cfg!(feature = "hmac-openssl");
+    let crypto = cfg!(feature = "hmac-rust-crypto");
+
+    if ssl && crypto {
+        panic!("`hmac-openssl` and `hmac-rust-crypto` features are mutually exclusive");
+    } else if !ssl && !crypto {
+        panic!("`hmac-openssl` or `hmac-rust-crypto` feature must be used");
+    }
+}

--- a/src/hmac/mod.rs
+++ b/src/hmac/mod.rs
@@ -1,0 +1,33 @@
+use ::SecretKey;
+
+#[cfg(feature = "hmac-rust-crypto")]
+mod rust_crypto;
+
+#[cfg(feature = "hmac-rust-crypto")]
+pub type Hmac256 = rust_crypto::RustCryptoHmac256;
+
+#[cfg(feature = "hmac-openssl")]
+mod ssl;
+
+#[cfg(feature = "hmac-openssl")]
+pub type Hmac256 = ssl::OpensslHmac256;
+
+
+pub trait HmacBuilder {
+    // Create the HMAC builder
+    fn new(secret: &SecretKey) -> Self;
+
+    // Add more input data
+    fn input(&mut self, data: &[u8]) -> &mut Self;
+
+    // Return the hmac digest
+    fn finalize(mut self) -> Vec<u8>;
+}
+
+/// Compute an HMAC using SHA-256 hashing
+pub fn hmac256(secret: &SecretKey, data: &[u8]) -> Vec<u8> {
+    let mut hmac = Hmac256::new(secret);
+    hmac.input(data);
+    hmac.finalize()
+}
+

--- a/src/hmac/rust_crypto.rs
+++ b/src/hmac/rust_crypto.rs
@@ -1,0 +1,38 @@
+use ::SecretKey;
+use super::HmacBuilder;
+
+use crypto::mac::Mac;
+use crypto::hmac::Hmac;
+use crypto::sha2::Sha256;
+
+pub struct RustCryptoHmac256 {
+    inner: ::crypto::hmac::Hmac<::crypto::sha2::Sha256>
+}
+
+impl HmacBuilder for RustCryptoHmac256 {
+    fn new(secret: &SecretKey) -> RustCryptoHmac256 {
+        RustCryptoHmac256 {
+            inner: Hmac::new(Sha256::new(), secret)
+        }
+    }
+
+    // Add more input data
+    fn input(&mut self, data: &[u8]) -> &mut RustCryptoHmac256 {
+        self.inner.input(data);
+        self
+    }
+
+    // Return the hmac digest
+    fn finalize(mut self) -> Vec<u8> {
+        let len = self.inner.output_bytes();
+        // Make vec for result
+        let mut result = Vec::with_capacity(len);
+        for _ in 0..len {
+            result.push(0);
+        }
+
+        self.inner.raw_result(&mut result[..]);
+
+        result
+    }
+}

--- a/src/hmac/ssl.rs
+++ b/src/hmac/ssl.rs
@@ -1,0 +1,30 @@
+use std::io::Write;
+
+use openssl::crypto::hash::Type;
+use openssl::crypto::hmac::HMAC;
+
+use super::HmacBuilder;
+use ::SecretKey;
+
+pub struct OpensslHmac256 {
+    inner: HMAC
+}
+
+impl HmacBuilder for OpensslHmac256 {
+    fn new(secret: &SecretKey) -> OpensslHmac256 {
+        OpensslHmac256 {
+            inner: HMAC::new(Type::SHA256, &secret[..])
+        }
+    }
+
+    // Add more input data
+    fn input(&mut self, data: &[u8]) -> &mut OpensslHmac256 {
+        self.inner.write_all(data).unwrap();
+        self
+    }
+
+    // Return the hmac digest
+    fn finalize(mut self) -> Vec<u8> {
+        self.inner.finish()
+    }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -6,12 +6,7 @@ use rustc_serialize::hex::ToHex;
 
 use constant_time_eq::constant_time_eq;
 
-use crypto::mac::Mac;
-use crypto::hmac::Hmac;
-use crypto::sha2::Sha256;
-
 use ::error::{Result};
-use ::SecretKey;
 
 // Vector extension from slice
 //
@@ -30,35 +25,6 @@ pub fn extend_vec(vec: &mut Vec<u8>, extension: &[u8]) {
             vec.set_len(len + 1);
         }
     }
-}
-
-pub trait HmacExt {
-    fn finalize(&mut self) -> Vec<u8>;
-}
-
-impl<D: ::crypto::digest::Digest> HmacExt for Hmac<D> {
-    fn finalize(&mut self) -> Vec<u8> {
-        let len = self.output_bytes();
-        // Make vec for result
-        let mut result = Vec::with_capacity(len);
-        for _ in 0..len {
-            result.push(0);
-        }
-
-        self.raw_result(&mut result[..]);
-
-        result
-    }
-}
-
-/// Compute an HMAC using SHA-256 hashing
-pub fn hmac256(secret: &SecretKey, data: &[u8]) -> Vec<u8> {
-    // Create hmac
-    let mut hmac = Hmac::new(Sha256::new(), &secret);
-
-    // Compute HMAC
-    hmac.input(data);
-    hmac.finalize()
 }
 
 /// Constant time equality comparison for byte lists


### PR DESCRIPTION
Rust-crypto is an (almost) pure rust implementation of various cryptographic functions. Their README still cautions against using their library in security-critical applications. However, openssl can be undesirable on windows due to build difficulty, and making a rust-crypto implementation available to consumers isn't preventing them from using the openssl implementation.
