### PR TITLE
Return 401 Unauthorized instead of 403 Forbidden

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,6 @@ optional = true
 git = "https://github.com/iron/body-parser"
 rev = "f9929111bd2efe7c29b519a5aa2d7bc32fddfac0"
 
-[dev-dependencies.hyper]
+[dependencies.hyper]
 version = "0.7"
 default-features = false

--- a/examples/hmac_middleware.rs
+++ b/examples/hmac_middleware.rs
@@ -23,7 +23,7 @@ fn main() {
     chain.link_after(hmac_after);
 
     // Server is now running
-    let server = Iron::new(chain).http("localhost:0").unwrap();
+    let server = Iron::new(chain).http("127.0.0.1:0").unwrap();
     let host = format!("{}", server.socket);
 
     println!("listening on {}", host);
@@ -31,6 +31,6 @@ fn main() {
     // If you want to query against this, perform a GET request and set the `x-hmac` header to
     // fa64feb94f1d649d435ae6dce009ff0767f57c0f20867dde5f8f6712fea3a7be
     //
-    // If you change the body, hmac, or request method, the response should be either forbidden or
-    // badrequest.
+    // If you change the body, hmac, or request method, the response should be either unauthorized
+    // or badrequest.
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -64,8 +64,8 @@ impl From<Error> for IronError {
     fn from(err: Error) -> IronError {
         match err {
             Error::MissingHmacHeader(_) => IronError::new(err, status::BadRequest),
-            Error::InvalidHmac => IronError::new(err, status::Forbidden),
-            Error::DecodingHex(_) => IronError::new(err, status::Forbidden),
+            Error::InvalidHmac => IronError::new(err, status::Unauthorized),
+            Error::DecodingHex(_) => IronError::new(err, status::Unauthorized),
             _ => IronError::new(err, status::InternalServerError)
         }
     }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,13 +1,13 @@
-/// Return an iron Error with status set to Forbidden
+/// Return an iron Error with status set to Unauthorized
 ///
 /// The error string indicates that HMAC auth failed
-macro_rules! forbidden {
+macro_rules! unauthorized {
     () => {{
         let err = ::error::Error::InvalidHmac;
-        return Err(::iron::IronError::new(err, ::iron::status::Forbidden));
+        return Err(::iron::IronError::new(err, ::iron::status::Unauthorized));
     }};
 
     ($err:expr) => {{
-        return Err(::iron::IronError::new($err, ::iron::status::Forbidden));
+        return Err(::iron::IronError::new($err, ::iron::status::Unauthorized));
     }};
 }


### PR DESCRIPTION
When authentication fails, the appropriate response is unauthorized.
Forbidden implies that you are authorized, but the requested resource is
not accessible to the requestor.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/jwilm/iron-hmac/6)

<!-- Reviewable:end -->
