### PR TITLE
Update all dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,39 +1,39 @@
 [package]
-name = "iron-hmac"
-version = "0.4.0"
 authors = ["Joe Wilm <joe@jwilm.com>"]
 description = "HMAC middleware for the Iron HTTP framework"
+documentation = "https://jwilm.github.io/iron-hmac/latest/iron_hmac/"
 license = "MIT OR Apache-2.0"
+name = "iron-hmac"
 readme = "README.md"
 repository = "https://github.com/jwilm/iron-hmac"
-documentation = "https://jwilm.github.io/iron-hmac/latest/iron_hmac/"
+version = "0.4.1"
+
+[dependencies]
+bodyparser = "0.6.0"
+constant_time_eq = "0.1.2"
+persistent = "0.3.0"
+rustc-serialize = "0.3.22"
+url = "1.4.0"
+
+[dependencies.iron]
+default-features = false
+version = "0.5.1"
+
+[dependencies.openssl]
+optional = true
+version = "0.9.7"
+
+[dependencies.rust-crypto]
+optional = true
+version = "0.2.36"
+
+[dev-dependencies]
+
+[dev-dependencies.hyper]
+default-features = false
+version = "0.10.4"
 
 [features]
 default = ["hmac-rust-crypto"]
-
-# Use openssl HMAC/SHA256 implementations
 hmac-openssl = ["openssl"]
-
-# Use rust-crypto HMAC/SHA256 implementations
 hmac-rust-crypto = ["rust-crypto"]
-
-[dependencies]
-constant_time_eq = "0.1"
-iron = { version = "0.4", default-features = false }
-persistent = "0.2"
-rustc-serialize = "0.3"
-
-[dependencies.openssl]
-version = "0.7"
-optional = true
-
-[dependencies.rust-crypto]
-version = "0.2"
-optional = true
-
-[dependencies.bodyparser]
-version = "0.4"
-
-[dev-dependencies.hyper]
-version = "0.8"
-default-features = false

--- a/src/hmac/mod.rs
+++ b/src/hmac/mod.rs
@@ -21,7 +21,7 @@ pub trait HmacBuilder {
     fn input(&mut self, data: &[u8]) -> &mut Self;
 
     // Return the hmac digest
-    fn finalize(mut self) -> Vec<u8>;
+    fn finalize(self) -> Vec<u8>;
 }
 
 /// Compute an HMAC using SHA-256 hashing

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,9 +48,9 @@ extern crate bodyparser;
 extern crate persistent;
 extern crate rustc_serialize;
 extern crate constant_time_eq;
+extern crate url;
 
 use iron::prelude::*;
-use iron::response::ResponseBody;
 use iron::{BeforeMiddleware, AfterMiddleware};
 use std::ops::Deref;
 
@@ -130,7 +130,7 @@ impl Hmac256Authentication {
         let method = req.method.as_ref();
 
         let method_hmac = hmac256(&self.secret, method.as_bytes());
-        let url = req.url.clone().into_generic_url();
+        let url: url::Url = req.url.clone().into();
         let path_hmac = hmac256(&self.secret, url.path().as_bytes());
         let body_hmac = hmac256(&self.secret, body.as_bytes());
 
@@ -147,7 +147,7 @@ impl Hmac256Authentication {
         let body: Vec<u8> = match res.body {
             Some(ref mut body) => {
                 let mut buf = util::Buffer::new();
-                try!(body.write_body(&mut ResponseBody::new(&mut buf)));
+                try!(body.write_body(&mut buf));
                 buf.to_inner()
             },
             None => Vec::new()


### PR DESCRIPTION
Especially update the Iron dependency to 0.5.1 since the definitions of the `BeforeMiddleware` and `AfterMiddleware` traits have changed preventing this library being used with the latest Iron server.

All tests pass and the external API is functionally unchanged.